### PR TITLE
fix(a2a-server): 更新依赖包以支持nacos服务发现

### DIFF
--- a/a2a_server/requirements.txt
+++ b/a2a_server/requirements.txt
@@ -1,2 +1,3 @@
 dify_plugin>=0.4.0,<0.7.0
 a2a-sdk==0.3.22
+nacos-maintainer-sdk-python==0.5.2


### PR DESCRIPTION
- 添加 nacos-maintainer-sdk-python==0.5.2 依赖
- 为系统增加nacos服务注册与发现功能支持
- 确保与现有依赖包版本兼容性