### PR TITLE
fix: 修复 MCP 客户端初始化时的解包错误 (兼容多返回值)

### DIFF
--- a/nacos_mcp/tools/call_mcp_tool.py
+++ b/nacos_mcp/tools/call_mcp_tool.py
@@ -32,7 +32,13 @@ class CallTool(Tool):
 				return streamablehttp_client(url=_url)
 
 		async def call_tools(_protocol: str, _url: str, _tool_name:str, _argument:dict):
-			async with get_clients(_protocol, _url) as (_read, _write):
+			async with get_clients(_protocol, _url) as streams:
+				# 根据返回值的长度进行解包，兼容不同版本的 mcp 库
+				if len(streams) == 2:
+					_read, _write = streams
+				else:
+					_read, _write, *rest = streams
+
 				async with ClientSession(_read, _write) as _session:
 					await _session.initialize()
 					_tools = await _session.call_tool(_tool_name, _argument)

--- a/nacos_mcp/tools/list_mcp_server_tools.py
+++ b/nacos_mcp/tools/list_mcp_server_tools.py
@@ -34,7 +34,12 @@ class ListTools(Tool):
                 return streamablehttp_client(url=_url)
 
         async def get_tools(_protocol:str, _url:str):
-            async with get_clients(_protocol, _url) as (_read, _write):
+            async with get_clients(_protocol, _url) as streams:
+                if len(streams) == 2:
+                    _read, _write = streams
+                else:
+                    _read, _write, *rest = streams
+
                 async with ClientSession(_read, _write) as _session:
                     await _session.initialize()
                     _tools = await _session.list_tools()


### PR DESCRIPTION
涉及文件:
- tools/call_mcp_tool.py
- tools/list_mcp_server_tools.py

问题描述:
两个文件在使用 mcp-streamable 协议时均报错：
ValueError: too many values to unpack (expected 2)

根本原因:
新版 mcp SDK 中的 streamablehttp_client 返回值由 2 个变为 3 个 (或更多)，导致原有 as (_read, _write) 解包逻辑失效。

修复方案:
- 将解包逻辑改为先获取返回值元组 streams
- 判断 len(streams) 长度
- 若长度 > 2，使用 *rest 吞噬多余参数
- 确保兼容 sse (2值) 和 streamable (3值) 两种协议