### PR TITLE
feat(a2a_server): map standard A2A metadata and data parts to Dify inputs

### DIFF
--- a/a2a_server/README.md
+++ b/a2a_server/README.md
@@ -71,6 +71,53 @@ If successful, you'll receive a JSON response with your agent's metadata.
 
 For sending messages via the POST endpoint, it's recommended to use an [A2A SDK](https://a2a-protocol.org/latest/sdk/) or A2A-compatible client.
 
+### Passing Structured Inputs to Dify
+
+This plugin maps standard A2A structured context into Dify app inputs:
+
+- `params.metadata` -> Dify `inputs`
+- `message.metadata` -> Dify `inputs`
+- `message.parts[].data` -> Dify `inputs`
+- `message.parts[].text` -> Dify `query`
+
+Merge order is request metadata, then message metadata, then data parts. Later values override earlier ones.
+
+Example `message/send` request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "message/send",
+  "params": {
+    "metadata": {
+      "userId": "u-123"
+    },
+    "message": {
+      "role": "user",
+      "kind": "message",
+      "messageId": "msg-1",
+      "metadata": {
+        "locale": "zh-CN"
+      },
+      "parts": [
+        {
+          "kind": "text",
+          "text": "Check my wallet balance"
+        },
+        {
+          "kind": "data",
+          "data": {
+            "accountId": "30054",
+            "sid": "session-token"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Configuration Reference
 
 | Parameter | Required | Default | Description |

--- a/a2a_server/endpoints/executor.py
+++ b/a2a_server/endpoints/executor.py
@@ -5,7 +5,7 @@ Dify App 执行器
 """
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
@@ -89,12 +89,58 @@ class DifyAppAgentExecutor(AgentExecutor):
         if message and message.parts:
             text_parts = []
             for part in message.parts:
-                if hasattr(part, 'text'):
-                    text_parts.append(part.text)
-                elif hasattr(part, 'root') and hasattr(part.root, 'text'):
-                    text_parts.append(part.root.text)
+                part_payload = self._unwrap_part(part)
+                if hasattr(part_payload, 'text') and part_payload.text:
+                    text_parts.append(part_payload.text)
             return '\n'.join(text_parts) if text_parts else ''
         return ''
+
+    def _unwrap_part(self, part):
+        """Unwrap A2A RootModel parts so handlers can inspect concrete payloads."""
+        return part.root if hasattr(part, 'root') else part
+
+    def _merge_input_values(
+        self,
+        current: dict[str, Any],
+        incoming: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Shallow-merge structured context into Dify inputs."""
+        if not incoming:
+            return current
+        for key, value in incoming.items():
+            current[key] = value
+        return current
+
+    def _extract_dify_inputs(self, context: RequestContext) -> dict[str, Any]:
+        """
+        Map standard A2A structured context into Dify inputs.
+
+        Mapping order:
+        1. Request-level params.metadata
+        2. Message-level message.metadata
+        3. Structured data from message.parts[].data
+
+        Later sources override earlier ones so explicit structured message data wins.
+        """
+        inputs: dict[str, Any] = {}
+
+        inputs = self._merge_input_values(inputs, context.metadata)
+
+        message = context.message
+        if not message:
+            return inputs
+
+        if getattr(message, 'metadata', None):
+            inputs = self._merge_input_values(inputs, message.metadata)
+
+        for part in message.parts or []:
+            part_payload = self._unwrap_part(part)
+            if getattr(part_payload, 'kind', None) != 'data':
+                continue
+            if isinstance(getattr(part_payload, 'data', None), dict):
+                inputs = self._merge_input_values(inputs, part_payload.data)
+
+        return inputs
     
     def _get_context_id(self, context: RequestContext) -> str:
         """从 A2A RequestContext 中提取 contextId"""
@@ -115,6 +161,7 @@ class DifyAppAgentExecutor(AgentExecutor):
         """
         # 1. 获取 A2A contextId
         a2a_context_id = self._get_context_id(context)
+        dify_inputs = self._extract_dify_inputs(context)
         
         # 2. 查找已有的 Dify conversation_id
         dify_conversation_id = ''
@@ -130,7 +177,7 @@ class DifyAppAgentExecutor(AgentExecutor):
             response_gen = self.session.app.chat.invoke(
                 app_id=self.app_id,
                 query=user_message,
-                inputs={},
+                inputs=dify_inputs,
                 response_mode='streaming',
                 conversation_id=dify_conversation_id or None,
             )
@@ -162,7 +209,7 @@ class DifyAppAgentExecutor(AgentExecutor):
                 # Workflow 接口（默认 blocking）
                 response = self.session.app.workflow.invoke(
                     app_id=self.app_id,
-                    inputs={'query': user_message},
+                    inputs=self._merge_input_values(dify_inputs.copy(), {'query': user_message}),
                     response_mode='blocking',
                 )
                 return self._extract_workflow_response(response)

--- a/a2a_server/readme/README_zh_Hans.md
+++ b/a2a_server/readme/README_zh_Hans.md
@@ -71,6 +71,53 @@ curl https://your-domain.com/e/{endpoint_id}/a2a/.well-known/agent.json
 
 如需通过 POST 接口发送消息，建议使用 [A2A SDK](https://a2a-protocol.org/latest/sdk/) 或 A2A 兼容的客户端。
 
+### 向 Dify 传递结构化输入
+
+这个插件会把标准 A2A 的结构化上下文映射到 Dify app 的 `inputs`：
+
+- `params.metadata` -> Dify `inputs`
+- `message.metadata` -> Dify `inputs`
+- `message.parts[].data` -> Dify `inputs`
+- `message.parts[].text` -> Dify `query`
+
+合并顺序为：请求级 metadata、消息级 metadata、`data part`。后出现的值覆盖前面的值。
+
+示例 `message/send` 请求：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "message/send",
+  "params": {
+    "metadata": {
+      "userId": "u-123"
+    },
+    "message": {
+      "role": "user",
+      "kind": "message",
+      "messageId": "msg-1",
+      "metadata": {
+        "locale": "zh-CN"
+      },
+      "parts": [
+        {
+          "kind": "text",
+          "text": "帮我查询钱包余额"
+        },
+        {
+          "kind": "data",
+          "data": {
+            "accountId": "30054",
+            "sid": "session-token"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
 ## 配置参数说明
 
 | 参数 | 必填 | 默认值 | 说明 |


### PR DESCRIPTION
## Summary

This PR updates the A2A Server plugin to forward standard A2A structured context into Dify app inputs.

### Mapping

- `params.metadata` -> Dify `inputs`
- `message.metadata` -> Dify `inputs`
- `message.parts[].data` -> Dify `inputs`
- `message.parts[].text` -> Dify `query`

## Why

Previously, the plugin only forwarded text parts into Dify `query` and used `inputs={}` when invoking the Dify app.

Because of that, Dify apps requiring hidden structured inputs such as `sid`, `accountId`, or `userId` could not work correctly through A2A.

## Changes

- Extract request metadata from A2A request context
- Extract message metadata from the A2A message
- Extract structured data from `message.parts[].data`
- Merge them into Dify `inputs`
- Keep text parts mapped to Dify `query`
- Update README examples in English and Chinese
